### PR TITLE
Add Webapp Deployment Role

### DIFF
--- a/roles/webapp/README.md
+++ b/roles/webapp/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/webapp/defaults/main.yml
+++ b/roles/webapp/defaults/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+---
+# defaults file for roles/webapp

--- a/roles/webapp/handlers/main.yml
+++ b/roles/webapp/handlers/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+---
+# handlers file for roles/webapp

--- a/roles/webapp/meta/main.yml
+++ b/roles/webapp/meta/main.yml
@@ -1,0 +1,35 @@
+#SPDX-License-Identifier: MIT-0
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/webapp/tasks/main.yml
+++ b/roles/webapp/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Deploy web index
+  ansible.builtin.copy:
+    dest: /var/www/html/index.html
+    content: "{{ web_index_content }}"
+    owner: www-data
+    group: www-data
+    mode: '0644'
+  become: yes

--- a/roles/webapp/tests/inventory
+++ b/roles/webapp/tests/inventory
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+localhost
+

--- a/roles/webapp/tests/test.yml
+++ b/roles/webapp/tests/test.yml
@@ -1,0 +1,6 @@
+#SPDX-License-Identifier: MIT-0
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - roles/webapp

--- a/roles/webapp/vars/main.yml
+++ b/roles/webapp/vars/main.yml
@@ -1,0 +1,3 @@
+#SPDX-License-Identifier: MIT-0
+---
+# vars file for roles/webapp


### PR DESCRIPTION
### Summary
Implements webapp deployment role as part of Ansible project.

### Changes
- Added tasks for webapp deployment
- Added handlers to restart service after deployment
- Added HTML template for base page
- Added default variables

### Linked Issue
Closes #3 